### PR TITLE
Moved from removed `OkJson` to `MultiJson`

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -171,9 +171,9 @@ module Heroku::Command
       resource = authenticated_resource("/status/#{@ranger_app_id}?api_key=#{@ranger_api_key}")
 
       begin
-        @current_status = Heroku::OkJson.decode(resource.get)
+        @current_status = MultiJson.load(resource.get)
         true
-      rescue Heroku::OkJson::Error => e
+      rescue MultiJson::ParseError => e
         false
       end
     end
@@ -198,7 +198,7 @@ module Heroku::Command
     end
 
     def delete_dependency_from_url(url)
-      dependencies = Heroku::OkJson.decode(get_dependencies)
+      dependencies = MultiJson.load(get_dependencies)
 
       dependency_id = nil
       dependencies.each do |record|
@@ -222,7 +222,7 @@ module Heroku::Command
     end
 
     def clear_all_dependencies
-      dependencies = Heroku::OkJson.decode(get_dependencies)
+      dependencies = MultiJson.load(get_dependencies)
 
       dependencies.each do |record|
         delete_dependency(record["dependency"]["id"])
@@ -265,7 +265,7 @@ module Heroku::Command
 
     def get_watchers
       resource = authenticated_resource("/apps/#{@ranger_app_id}/watchers.json?api_key=#{@ranger_api_key}")
-      @current_watchers = Heroku::OkJson.decode(resource.get)
+      @current_watchers = MultiJson.load(resource.get)
     end
 
     def watchers_list


### PR DESCRIPTION
As of March 7 2014, `Heroku::OkJson` no longer exists.

https://github.com/heroku/heroku/commit/132df5cd75a59b1427e677fceb2db440efac7098#diff-0efbd84cf2791121a9643b549a423f99

https://github.com/heroku/heroku/commit/24751ef8d82d53f88e3a7ab2089b6f75c860812a#diff-0efbd84cf2791121a9643b549a423f99

This has been causing errors in the `ranger` plugin. To repair this, we are moving to `MultiJson` which is the new library that Heroku is using for its `json_decode`:

https://github.com/heroku/heroku/blob/v3.26.0/lib/heroku/helpers.rb#L211-L215

In this PR:

- Move all `Heroku::OkJson` references to their `MultiJson` equivalent